### PR TITLE
Add .gitattributes to avoid conflicting eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# https://git-scm.com/docs/gitattributes/#_end_of_line_conversion
+*	text=auto


### PR DESCRIPTION
The problem usually occurs when developers using different OSes (ex. Linux and Windows). See https://git-scm.com/docs/gitattributes#_end_of_line_conversion